### PR TITLE
security(jwt): enforce HS256 token parsing

### DIFF
--- a/internal/util/jwt.go
+++ b/internal/util/jwt.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -29,6 +30,9 @@ func SignJWT(secret string, userID string, username string, ttlMin int) (string,
 
 func ParseJWT(secret string, tokenStr string) (*Claims, error) {
 	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(token *jwt.Token) (any, error) {
+		if token.Method != jwt.SigningMethodHS256 {
+			return nil, errors.New("unexpected jwt signing method")
+		}
 		return []byte(secret), nil
 	})
 	if err != nil {

--- a/internal/util/jwt_test.go
+++ b/internal/util/jwt_test.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func TestSignAndParseJWT(t *testing.T) {
@@ -38,5 +40,23 @@ func TestParseJWTRejectsWrongSecret(t *testing.T) {
 
 	if _, err := ParseJWT("secret-b", token); err == nil {
 		t.Fatalf("expected ParseJWT to fail with wrong secret")
+	}
+}
+
+func TestParseJWTRejectsUnexpectedSigningMethod(t *testing.T) {
+	secret := "test-secret"
+	claims := Claims{
+		Sub:      "user-123",
+		Username: "anouar",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)
+	tokenStr, err := token.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("failed to sign test token: %v", err)
+	}
+
+	if _, err := ParseJWT(secret, tokenStr); err == nil {
+		t.Fatalf("expected ParseJWT to reject non-HS256 token")
 	}
 }


### PR DESCRIPTION
## Summary
Adds explicit HS256 signing method enforcement in JWT parsing and tests for rejection of non-HS256 tokens.

## Validation
- go test ./...

Closes #1