### PR TITLE
feat(auth): stabilize /auth/me response contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ API base URL: `http://localhost:8080`
 - `POST /auth/register`
 - `POST /auth/login`
 - `GET /auth/me` (requires `Authorization: Bearer <token>`)
+  - Returns `userId`, `username`, and `requestId` when request tracing middleware is active
 
 ## Development Commands
 

--- a/internal/http/handlers/auth.go
+++ b/internal/http/handlers/auth.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"chess-training/internal/http/middleware"
 	"chess-training/internal/service"
 	"github.com/gin-gonic/gin"
 )
@@ -61,8 +62,30 @@ func (h *AuthHandler) Login(c *gin.Context) {
 }
 
 func Me(c *gin.Context) {
-	// middleware put values; handler just echoes for now
-	userID, _ := c.Get("user_id")
-	username, _ := c.Get("username")
-	c.JSON(http.StatusOK, gin.H{"userId": userID, "username": username})
+	response := meResponse{
+		UserID:    contextString(c, middleware.CtxUserIDKey),
+		Username:  contextString(c, middleware.CtxUsernameKey),
+		RequestID: contextString(c, requestIDContextKey),
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+type meResponse struct {
+	UserID    string `json:"userId"`
+	Username  string `json:"username"`
+	RequestID string `json:"requestId,omitempty"`
+}
+
+const requestIDContextKey = "request_id"
+
+func contextString(c *gin.Context, key string) string {
+	raw, exists := c.Get(key)
+	if !exists {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return value
 }

--- a/internal/http/handlers/me_test.go
+++ b/internal/http/handlers/me_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"chess-training/internal/http/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func TestMeIncludesIdentityAndRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	ctx.Set(middleware.CtxUserIDKey, "user-99")
+	ctx.Set(middleware.CtxUsernameKey, "anouar")
+	ctx.Set(requestIDContextKey, "req-abc")
+
+	Me(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse response JSON: %v", err)
+	}
+	if payload["userId"] != "user-99" {
+		t.Fatalf("expected userId user-99, got %v", payload["userId"])
+	}
+	if payload["username"] != "anouar" {
+		t.Fatalf("expected username anouar, got %v", payload["username"])
+	}
+	if payload["requestId"] != "req-abc" {
+		t.Fatalf("expected requestId req-abc, got %v", payload["requestId"])
+	}
+}
+
+func TestMeOmitsRequestIDWhenMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	ctx.Set(middleware.CtxUserIDKey, "user-77")
+	ctx.Set(middleware.CtxUsernameKey, "reader")
+
+	Me(ctx)
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse response JSON: %v", err)
+	}
+	if _, exists := payload["requestId"]; exists {
+		t.Fatalf("expected requestId to be omitted when missing")
+	}
+}


### PR DESCRIPTION
## Summary
Returns a typed /auth/me payload with optional requestId and adds handler tests for contract stability.

## Validation
- go test ./...

Closes #12