### PR TITLE
feat(config): add APP_ENV validation and health env visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ export JWT_SECRET="change-me"
 export JWT_TTL_MIN="120"
 # optional (default: :8080)
 export HTTP_ADDR=":8080"
+# optional (default: dev): one of dev|test|staging|prod
+export APP_ENV="dev"
 ```
 
 Validation rules:
 - `DATABASE_URL` is required
 - `JWT_SECRET` is required
 - `JWT_TTL_MIN` must be a positive integer
+- `APP_ENV` must be one of `dev`, `test`, `staging`, `prod`
 
 3. Apply migrations (if you have `migrate` CLI installed):
 
@@ -50,7 +53,7 @@ API base URL: `http://localhost:8080`
 
 ## Main Endpoints
 
-- `GET /healthz`
+- `GET /healthz` (returns `ok` and `env`)
 - `POST /auth/register`
 - `POST /auth/login`
 - `GET /auth/me` (requires `Authorization: Bearer <token>`)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("api listening on %s", cfg.HTTPAddr)
+		log.Printf("api listening on %s (env=%s)", cfg.HTTPAddr, cfg.AppEnv)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("listen failed: %v", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	DatabaseURL string
 	JWTSecret   string
 	JWTTTLMin   int
+	AppEnv      string
 }
 
 func Load() (Config, error) {
@@ -29,6 +30,10 @@ func Load() (Config, error) {
 	if addr == "" {
 		addr = ":8080"
 	}
+	appEnv, err := resolveAppEnv(os.Getenv("APP_ENV"))
+	if err != nil {
+		return Config{}, err
+	}
 
 	databaseURL, err := requiredEnv("DATABASE_URL")
 	if err != nil {
@@ -44,6 +49,7 @@ func Load() (Config, error) {
 		DatabaseURL: databaseURL,
 		JWTSecret:   jwtSecret,
 		JWTTTLMin:   ttl,
+		AppEnv:      appEnv,
 	}, nil
 }
 
@@ -53,4 +59,16 @@ func requiredEnv(k string) (string, error) {
 		return "", fmt.Errorf("missing env var: %s", k)
 	}
 	return v, nil
+}
+
+func resolveAppEnv(raw string) (string, error) {
+	if raw == "" {
+		return "dev", nil
+	}
+	switch raw {
+	case "dev", "test", "staging", "prod":
+		return raw, nil
+	default:
+		return "", fmt.Errorf("invalid APP_ENV: %s", raw)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ func TestLoadUsesDefaults(t *testing.T) {
 	t.Setenv("JWT_SECRET", "super-secret")
 	t.Setenv("HTTP_ADDR", "")
 	t.Setenv("JWT_TTL_MIN", "")
+	t.Setenv("APP_ENV", "")
 
 	cfg, err := Load()
 	if err != nil {
@@ -21,6 +22,9 @@ func TestLoadUsesDefaults(t *testing.T) {
 	}
 	if cfg.JWTTTLMin != 120 {
 		t.Fatalf("expected default ttl 120, got %d", cfg.JWTTTLMin)
+	}
+	if cfg.AppEnv != "dev" {
+		t.Fatalf("expected default app env dev, got %q", cfg.AppEnv)
 	}
 }
 
@@ -77,5 +81,40 @@ func TestLoadRequiresJWTSecret(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "JWT_SECRET") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsInvalidAppEnv(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("JWT_SECRET", "super-secret")
+	t.Setenv("JWT_TTL_MIN", "")
+	t.Setenv("APP_ENV", "production")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatalf("expected Load to fail when APP_ENV is invalid")
+	}
+	if !strings.Contains(err.Error(), "APP_ENV") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadAcceptsSupportedAppEnv(t *testing.T) {
+	supported := []string{"dev", "test", "staging", "prod"}
+	for _, env := range supported {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "postgres://example")
+			t.Setenv("JWT_SECRET", "super-secret")
+			t.Setenv("JWT_TTL_MIN", "")
+			t.Setenv("APP_ENV", env)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load returned error: %v", err)
+			}
+			if cfg.AppEnv != env {
+				t.Fatalf("expected app env %q, got %q", env, cfg.AppEnv)
+			}
+		})
 	}
 }

--- a/internal/http/handlers/health.go
+++ b/internal/http/handlers/health.go
@@ -1,7 +1,15 @@
 package handlers
 
-import "github.com/gin-gonic/gin"
+import (
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
 
 func Healthz(c *gin.Context) {
-	c.JSON(200, gin.H{"ok": true})
+	env := os.Getenv("APP_ENV")
+	if env == "" {
+		env = "dev"
+	}
+	c.JSON(200, gin.H{"ok": true, "env": env})
 }

--- a/internal/http/handlers/health_test.go
+++ b/internal/http/handlers/health_test.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHealthzDefaultsToDevEnv(t *testing.T) {
+	t.Setenv("APP_ENV", "")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	Healthz(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if payload["ok"] != true {
+		t.Fatalf("expected ok=true, got %v", payload["ok"])
+	}
+	if payload["env"] != "dev" {
+		t.Fatalf("expected env=dev, got %v", payload["env"])
+	}
+}
+
+func TestHealthzUsesConfiguredEnv(t *testing.T) {
+	t.Setenv("APP_ENV", "staging")
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	Healthz(ctx)
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if payload["env"] != "staging" {
+		t.Fatalf("expected env=staging, got %v", payload["env"])
+	}
+}


### PR DESCRIPTION
## Summary
Introduces APP_ENV config validation, surfaces env in health endpoint, and adds test coverage.

## Validation
- go test ./...

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `APP_ENV` environment variable to configure application environment (dev, test, staging, prod; defaults to dev).
  * The `/healthz` endpoint now returns the application environment in its response.

* **Documentation**
  * Updated README with `APP_ENV` configuration documentation and clarified `/healthz` endpoint behavior.

* **Tests**
  * Added comprehensive health endpoint tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->