### PR TITLE
test(auth): add bearer parser edge-case coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ API base URL: `http://localhost:8080`
 - `POST /auth/login`
 - `GET /auth/me` (requires `Authorization: Bearer <token>`)
 
+Authorization header format for protected routes:
+- `Authorization: Bearer <jwt>`
+
 ## Development Commands
 
 ```bash

--- a/internal/http/middleware/auth_header_test.go
+++ b/internal/http/middleware/auth_header_test.go
@@ -1,0 +1,38 @@
+package middleware
+
+import "testing"
+
+func TestBearerTokenFromAuthorizationHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid bearer", header: "Bearer abc.def.ghi", want: "abc.def.ghi"},
+		{name: "case insensitive scheme", header: "bearer token123", want: "token123"},
+		{name: "extra spaces", header: "Bearer   token-xyz", want: "token-xyz"},
+		{name: "missing header", header: "", wantErr: true},
+		{name: "missing token", header: "Bearer", wantErr: true},
+		{name: "wrong scheme", header: "Basic 123", wantErr: true},
+		{name: "too many parts", header: "Bearer first second", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := bearerTokenFromAuthorizationHeader(tt.header)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected token %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds table-driven tests for Authorization bearer parsing, including malformed header scenarios.

## Validation
- go test ./...

Closes #21